### PR TITLE
feat: add homepage_url

### DIFF
--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -8,6 +8,7 @@ export default defineConfig({
     description: 'Quick access to deployment previews in GitHub Pull Requests',
     permissions: [],
     host_permissions: ['https://github.com/*'],
+    homepage_url: "https://github.com/liruifengv/github-pr-preview/issues",
   },
   outDir: "dist",
   modules: ['@wxt-dev/auto-icons'],


### PR DESCRIPTION
可以考虑像 https://github.com/refined-github/refined-github 做一个快速跳转到仓库，有助于收集反馈或贡献。

增强插件确实让 github 好用了不少。

![Image](https://github.com/user-attachments/assets/6107506e-c5e4-4e63-83a4-6c3db92853e1)

![Image](https://github.com/user-attachments/assets/4abdc39e-298c-488d-ad65-1776c19fbfd6)